### PR TITLE
CB-12169: Check for build directory before running a clean

### DIFF
--- a/bin/templates/cordova/Api.js
+++ b/bin/templates/cordova/Api.js
@@ -72,6 +72,7 @@ function Api(platform, platformRootDir, events) {
         defaultConfigXml: path.join(self.root, 'cordova/defaults.xml'),
         strings: path.join(self.root, 'res/values/strings.xml'),
         manifest: path.join(self.root, 'AndroidManifest.xml'),
+        build: path.join(self.root, 'build'),
         // NOTE: Due to platformApi spec we need to return relative paths here
         cordovaJs: 'bin/templates/project/assets/www/cordova.js',
         cordovaJsSrc: 'cordova-js-src'
@@ -241,11 +242,12 @@ Api.prototype.addPlugin = function (plugin, installOptions) {
            // Do some basic argument parsing
             var opts = {};
 
-            // Skip cleaning prepared files when not invoking via cordova CLI.
+             // Skip cleaning prepared files when not invoking via cordova CLI.
             opts.noPrepare = true;
 
-            if(!(AndroidStudio.isAndroidStudioProject(self.root)))
+            if(!AndroidStudio.isAndroidStudioProject(self.root) && !project.isClean()) {
               return self.clean(opts);
+            }
         })
        .then(function () {
             return PluginManager.get(self.platform, self.locations, project)
@@ -395,6 +397,8 @@ Api.prototype.clean = function(cleanOptions) {
           return require('./lib/prepare').clean.call(self, cleanOptions);
       });
 };
+
+
 
 /**
  * Performs a requirements check for current platform. Each platform defines its

--- a/bin/templates/cordova/lib/AndroidProject.js
+++ b/bin/templates/cordova/lib/AndroidProject.js
@@ -197,5 +197,14 @@ AndroidProject.prototype.getUninstaller = function (type) {
     return pluginHandlers.getUninstaller(type);
 };
 
+/*
+ * This checks if an Android project is clean or has old build artifacts
+ */
+
+AndroidProject.prototype.isClean = function() {
+    var build_path = path.join(this.projectDir, "build");
+    //If the build directory doesn't exist, it's clean
+    return !(fs.existsSync(build_path));
+};
 
 module.exports = AndroidProject;


### PR DESCRIPTION
cherry-pick from cordova-android [#5017e230](https://github.com/apache/cordova-android/commit/5017e2302b90f8555bb105dc5a90b0483b384280).
Jira issue: [CB-12169](https://issues.apache.org/jira/browse/CB-12169).
On every plugin install Cordova check if our project is Android studio project and if it is not they trigger Gradle clean task which is unnecessary if the project is clean.